### PR TITLE
Get ruby hash first and then generate output string in all examples.

### DIFF
--- a/BreakSentence.rb
+++ b/BreakSentence.rb
@@ -33,5 +33,5 @@ end
 
 result = response.body.force_encoding("utf-8")
 
-json = JSON.pretty_generate(JSON.parse(result))
-puts json
+hash = JSON.parse(result)
+puts JSON.pretty_generate(hash)

--- a/Detect.rb
+++ b/Detect.rb
@@ -33,5 +33,5 @@ end
 
 result = response.body.force_encoding("utf-8")
 
-json = JSON.pretty_generate(JSON.parse(result))
-puts json
+hash = JSON.parse(result)
+puts JSON.pretty_generate(hash)

--- a/DictionaryExamples.rb
+++ b/DictionaryExamples.rb
@@ -36,5 +36,5 @@ end
 
 result = response.body.force_encoding("utf-8")
 
-json = JSON.pretty_generate(JSON.parse(result))
-puts json
+hash = JSON.parse(result)
+puts JSON.pretty_generate(hash)

--- a/DictionaryLookup.rb
+++ b/DictionaryLookup.rb
@@ -35,5 +35,5 @@ end
 
 result = response.body.force_encoding("utf-8")
 
-json = JSON.pretty_generate(JSON.parse(result))
-puts json
+hash = JSON.parse(result)
+puts JSON.pretty_generate(hash)

--- a/Languages.rb
+++ b/Languages.rb
@@ -24,7 +24,7 @@ end
 
 result = response.body.force_encoding("utf-8")
 
-json = JSON.pretty_generate(JSON.parse(result))
+hash = JSON.parse(result)
 
 output_path = 'output.txt'
 

--- a/Translate.rb
+++ b/Translate.rb
@@ -36,5 +36,5 @@ end
 
 result = response.body.force_encoding("utf-8")
 
-json = JSON.pretty_generate(JSON.parse(result))
-puts json
+hash = JSON.parse(result)
+puts JSON.pretty_generate(hash)

--- a/Transliterate.rb
+++ b/Transliterate.rb
@@ -37,5 +37,5 @@ end
 
 result = response.body.force_encoding("utf-8")
 
-json = JSON.pretty_generate(JSON.parse(result))
-puts json
+hash = JSON.parse(result)
+puts JSON.pretty_generate(hash)


### PR DESCRIPTION
Ruby hash will be easy to go next, and
JSON.pretty_generate will generate a pretty output for terminal usage.

I think this change will be more easy for rubyist to use API!